### PR TITLE
Add ANU support and fix issue with strange course titles

### DIFF
--- a/Source/downloadecho360video.js
+++ b/Source/downloadecho360video.js
@@ -25,8 +25,9 @@ function downloadVideos() {
     if (typeof $ === 'undefined') {
         return false;
     }
-    
-    coursename = $('#course-info').text();
+
+    var course_s = $('#course-info').text();
+    coursename = course_s.replace(/[^a-z0-9 ]/gi, '-');
 
     //Start looking for download URL
 

--- a/Source/university.json
+++ b/Source/university.json
@@ -6,6 +6,9 @@
         "abbr": "Monash",
         "url": "https://mulo-portal.lib.monash.edu/ess/portal/section/",
         "icon_128": "icon128_monash.png"
+    }, {
+        "abbr": "ANU",
+        "url": "https://capture.anu.edu.au:8443/ess/portal/section/",
+        "icon_128": "icon128_anu.png"
     }
-
 ]


### PR DESCRIPTION
Without d67fdd1 the download fails for many ANU courses as they have titles like "Advanced Analysis 2: Topology, Lebesgue Integration and Hilbert Spaces - MATH3320/MATH6212"

For ANU, it now works when Echo is popped out of the LMS, I'm not sure why, but in the LMS frame page the extension only runs on the top frame, not index.jsp.
